### PR TITLE
Change

### DIFF
--- a/DMT/Patches/BuiltInPatches.cs
+++ b/DMT/Patches/BuiltInPatches.cs
@@ -29,12 +29,12 @@ namespace DMT.Patches
         {
             Logging.Log("Hooking harmony");
 
-            var gm = game.Types.FirstOrDefault(d => d.Name == "GameManager");
-            var awakeMethod = gm.Methods.First(d => d.Name == "Awake");
+            var steam = game.Types.FirstOrDefault(d => d.Name == "Steam");
+            var singletonCreated = steam.Methods.First(d => d.Name == "singletonCreated");
             var helper = mod.Types.First(d => d.Name == "DMTChanges");
             var hookHarmony = game.Import(helper.Methods.First(d => d.Name == "HookHarmony"));
 
-            var pro = awakeMethod.Body.GetILProcessor();
+            var pro = singletonCreated.Body.GetILProcessor();
             var body = pro.Body.Instructions;
             var ins = body.First(d => d.OpCode == OpCodes.Newobj);
 


### PR DESCRIPTION
Changed the method Harmony will hook in from GameManager::Awake to Steam::singletonCreated to allow the creation of Harmony patches to take place before the game's main menu is initialized.